### PR TITLE
Maps over fields rather than index into option.fields

### DIFF
--- a/options/options.js
+++ b/options/options.js
@@ -30,8 +30,8 @@ function buildOptions(moduleIndex) {
       // loop through fields
       $fields.append(...option.fields.map((field) =>
         `<div class="option-${i} field-row">
-<label>${option.fields[j].description}: </label>
-<input type="text" class="${option.fields[j].isColor ? "color" : ""}" value="${option.fields[j].val || ""}">
+<label>${field.description}: </label>
+<input type="text" class="${field.isColor ? "color" : ""}" value="${field.val || ""}">
 </div>`));
       // add field to option
       optionSection.push($fields);


### PR DESCRIPTION
Looks like you didn't change options.js to use the map syntax. This error is thrown when you try to set the Options for a Module.

```
options.js:33 Uncaught ReferenceError: j is not defined
    at $fields.append.option.fields.map (options.js:33)
    at Array.map (<anonymous>)
    at options.forEach (options.js:31)
    at Array.forEach (<anonymous>)
    at buildOptions (options.js:18)
    at HTMLButtonElement.$.on (dashboard.js:31)
    at HTMLUListElement.dispatch (jquery.min.js:3)
    at HTMLUListElement.q.handle (jquery.min.js:3)
```

This commit replaces `option.fields[j]` with `field`.